### PR TITLE
Edition d'un ID d'album sur plus d'un digit

### DIFF
--- a/public/javascripts/albumtable.js
+++ b/public/javascripts/albumtable.js
@@ -58,7 +58,7 @@
             var t = $(this);
             
             var album = t.closest('tr').attr("id");
-            var id = album.match(/album-(\d)/)[1];
+            var id = album.match(/album-(\d+)/)[1];
 
             displayCover(id, t);
         });


### PR DESCRIPTION
Le script du showCover ne fonctionnait pas sur un id d'album >= 10 (plus d'un digit)
Le patch change juste la regexp JS que tu utilisais.
